### PR TITLE
fix: add missing latestSolidifiedBlockNumber field to BlockLogTrigger

### DIFF
--- a/api/src/main/java/org/tron/common/logsfilter/trigger/BlockLogTrigger.java
+++ b/api/src/main/java/org/tron/common/logsfilter/trigger/BlockLogTrigger.java
@@ -22,6 +22,10 @@ public class BlockLogTrigger extends Trigger {
 
   @Getter
   @Setter
+  private long latestSolidifiedBlockNumber;
+
+  @Getter
+  @Setter
   private List<String> transactionList = new ArrayList<>();
 
 
@@ -47,7 +51,7 @@ public class BlockLogTrigger extends Trigger {
   @Override
   public String toString() {
     return new StringBuilder().append("triggerName: ").append(getTriggerName())
-      .append("timestamp: ")
+      .append(", timestamp: ")
       .append(timeStamp)
       .append(", blockNumber: ")
       .append(blockNumber)
@@ -55,6 +59,8 @@ public class BlockLogTrigger extends Trigger {
       .append(blockHash)
       .append(", transactionSize: ")
       .append(transactionSize)
+      .append(", latestSolidifiedBlockNumber: ")
+      .append(latestSolidifiedBlockNumber)
       .append(", transactionList: ")
       .append(transactionList)
       .append(", witnessAddress: ")


### PR DESCRIPTION
## 描述

添加缺失的 \`latestSolidifiedBlockNumber\` 字段到 \`BlockLogTrigger\` 类中。

## 修改内容

1. **添加 latestSolidifiedBlockNumber 字段**：
   - 添加了 \`@Getter\` 和 \`@Setter\` 注解
   - 字段类型为 \`long\`

2. **更新 toString() 方法**：
   - 在输出中包含 \`latestSolidifiedBlockNumber\` 字段
   - 修复了格式问题，在 timestamp 前添加了逗号分隔符

## 影响范围

- \`BlockLogTrigger\` 类现在包含完整的区块信息，包括最新固化区块号
- 确保日志输出的一致性和完整性

 

## 相关问题

此修改解决了 \`BlockLogTrigger\` 类中缺少 \`latestSolidifiedBlockNumber\` 字段的问题，确保触发器包含完整的区块状态信息。