### PR TITLE
version(3.0.0): replace fastjson with jackson

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Event-plugin can be built with JDK 8 or JDK 17.
 2. Go to eventplugin `cd eventplugin` 
 3. run `./gradlew build`
 
-* This will produce plugin zips, named `plugin-kafka-1.0.0.zip` and `plugin-mongodb-1.0.0.zip`, located in the `eventplugin/build/plugins/` directory.
+* This will produce plugin zips, named `plugin-kafka-3.0.0.zip` and `plugin-mongodb-3.0.0.zip`, located in the `eventplugin/build/plugins/` directory.
 
 
 ### Edit **config.conf** of Java-tron, add the following fields:
@@ -82,7 +82,7 @@ event.subscribe = {
 
 
 ```
- * **path**: is the absolute path of "plugin-kafka-1.0.0.zip" or "plugin-mongodb-1.0.0.zip"
+ * **path**: is the absolute path of "plugin-kafka-3.0.0.zip" or "plugin-mongodb-3.0.0.zip"
  * **server**: Kafka(or MongoDB) server address, the default port is 9092(MongoDB is 27017)
  * **dbconfig**: db configuration information for mongodb, if using kafka, delete this one; if using Mongodb, add like that dbname|username|password or dbname|username|password|version if you want to create indexes when init
  * **topics**: each event type maps to one Kafka topic(or MongoDB collection), we support seven event types subscribing, block, transaction, contractlog, contractevent, solidity, soliditylog and solidityevent.   

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,11 +9,10 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.slf4j:slf4j-api:2.0.9'
     implementation 'ch.qos.logback:logback-classic:1.3.14'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.6'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.6'
     implementation "com.madgag.spongycastle:core:1.58.0.0"
     implementation "com.madgag.spongycastle:prov:1.58.0.0"
-    implementation 'com.alibaba:fastjson:1.2.83'
 }
 
 task uberjar(type: Jar, dependsOn: ['compileJava']) {

--- a/app/src/main/java/org/tron/eventplugin/app/PluginLauncher.java
+++ b/app/src/main/java/org/tron/eventplugin/app/PluginLauncher.java
@@ -35,7 +35,7 @@ import org.tron.common.logsfilter.trigger.EventTopic;
 public class PluginLauncher {
 
   public static void main(String[] args) {
-    String path = "/Users/tron/sourcecode/eventplugin/build/plugins/plugin-mongodb-1.0.0.zip";
+    String path = "/Users/tron/sourcecode/eventplugin/build/plugins/plugin-mongodb-3.0.0.zip";
 
     File dir = new File(path);
     // create the plugin manager

--- a/plugins/kafkaplugin/build.gradle
+++ b/plugins/kafkaplugin/build.gradle
@@ -2,7 +2,9 @@ dependencies {
     // compileOnly important!!! We do not want to put the api into the zip file since the main program has it already!
     compileOnly project(':api')
 
-    compileOnly group: 'com.alibaba', name: 'fastjson', version: '1.2.83'
+    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.6'
+    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.18.6'
+
     implementation("org.apache.kafka:kafka-clients:3.9.1") {
         exclude group: "org.slf4j"
         exclude group: 'org.lz4', module: 'lz4-java'

--- a/plugins/kafkaplugin/gradle.properties
+++ b/plugins/kafkaplugin/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.0
+version=3.0.0
 
 pluginId=kafka
 pluginClass=org.tron.eventplugin.KafkaLogFilterPlugin

--- a/plugins/kafkaplugin/src/main/java/org/tron/eventplugin/KafkaSenderImpl.java
+++ b/plugins/kafkaplugin/src/main/java/org/tron/eventplugin/KafkaSenderImpl.java
@@ -1,6 +1,7 @@
 package org.tron.eventplugin;
 
-import com.alibaba.fastjson.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -21,6 +22,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 @Slf4j(topic = "event")
 public class KafkaSenderImpl implements AutoCloseable {
 
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static KafkaSenderImpl instance = null;
 
   @Setter
@@ -220,13 +222,13 @@ public class KafkaSenderImpl implements AutoCloseable {
               continue;
             }
             // check if it's json
-            JSONObject jsonObject = JSONObject.parseObject(triggerData);
+            JsonNode jsonObject = OBJECT_MAPPER.readTree(triggerData);
 
-            if (!jsonObject.containsKey("triggerName")) {
+            if (!jsonObject.has("triggerName")) {
               log.error("Invalid triggerData without triggerName: {}", triggerData);
               continue;
             }
-            String triggerName = jsonObject.getString("triggerName");
+            String triggerName = getString(jsonObject, "triggerName");
             EventTopic eventTopic = EventTopic.getEventTopicByName(triggerName);
             if (eventTopic == null) {
               log.error("Not matched triggerName {} in data {}", triggerName, triggerData);
@@ -265,6 +267,14 @@ public class KafkaSenderImpl implements AutoCloseable {
           }
         }
       };
+
+  private String getString(JsonNode node, String key) {
+    JsonNode value = node.get(key);
+    if (Objects.isNull(value) || value.isNull()) {
+      return null;
+    }
+    return value.asText();
+  }
 
   @Override
   public void close() {

--- a/plugins/mongodbplugin/build.gradle
+++ b/plugins/mongodbplugin/build.gradle
@@ -2,9 +2,8 @@ dependencies {
     // compileOnly important!!! We do not want to put the api into the zip file since the main program has it already!
     compileOnly project(':api')
 
-    compileOnly group: 'com.alibaba', name: 'fastjson', version: '1.2.83'
-    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.3'
-    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.18.3'
+    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.6'
+    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.18.6'
 
     implementation("org.mongodb:mongo-java-driver:3.12.10") {
         exclude group: "org.slf4j"

--- a/plugins/mongodbplugin/gradle.properties
+++ b/plugins/mongodbplugin/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.0
+version=3.0.0
 
 pluginId=mongodb
 pluginClass=org.tron.eventplugin.MongodbLogFilterPlugin

--- a/plugins/mongodbplugin/src/main/java/org/tron/eventplugin/MongodbSenderImpl.java
+++ b/plugins/mongodbplugin/src/main/java/org/tron/eventplugin/MongodbSenderImpl.java
@@ -1,7 +1,7 @@
 package org.tron.eventplugin;
 
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +22,7 @@ import org.tron.mongodb.MongoTemplate;
 @Slf4j(topic = "event")
 public class MongodbSenderImpl implements AutoCloseable {
 
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static MongodbSenderImpl instance = null;
   @Getter
   BlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>();
@@ -270,8 +271,8 @@ public class MongodbSenderImpl implements AutoCloseable {
   public void upsertEntityLong(MongoTemplate template, Object data, String indexKey) {
     String dataStr = (String) data;
     try {
-      JSONObject jsStr = JSON.parseObject(dataStr);
-      Long indexValue = jsStr.getLong(indexKey);
+      JsonNode jsStr = OBJECT_MAPPER.readTree(dataStr);
+      Long indexValue = getLong(jsStr, indexKey);
       if (indexValue != null) {
         template.upsertEntity(indexKey, indexValue, dataStr);
       } else {
@@ -285,8 +286,8 @@ public class MongodbSenderImpl implements AutoCloseable {
   public void upsertEntityString(MongoTemplate template, Object data, String indexKey) {
     String dataStr = (String) data;
     try {
-      JSONObject jsStr = JSON.parseObject(dataStr);
-      String indexValue = jsStr.getString(indexKey);
+      JsonNode jsStr = OBJECT_MAPPER.readTree(dataStr);
+      String indexValue = getString(jsStr, indexKey);
       if (indexValue != null) {
         template.upsertEntity(indexKey, indexValue, dataStr);
       } else {
@@ -379,8 +380,8 @@ public class MongodbSenderImpl implements AutoCloseable {
         String dataStr = (String) data;
         if (dataStr.contains("\"removed\":true")) {
           try {
-            JSONObject jsStr = JSON.parseObject(dataStr);
-            String uniqueId = jsStr.getString("uniqueId");
+            JsonNode jsStr = OBJECT_MAPPER.readTree(dataStr);
+            String uniqueId = getString(jsStr, "uniqueId");
             if (uniqueId != null) {
               template.delete("uniqueId", uniqueId);
             }
@@ -426,13 +427,13 @@ public class MongodbSenderImpl implements AutoCloseable {
               continue;
             }
             // check if it's json
-            JSONObject jsonObject = JSONObject.parseObject(triggerData);
+            JsonNode jsonObject = OBJECT_MAPPER.readTree(triggerData);
 
-            if (!jsonObject.containsKey("triggerName")) {
+            if (!jsonObject.has("triggerName")) {
               log.error("Invalid triggerData without triggerName: {}", triggerData);
               continue;
             }
-            String triggerName = jsonObject.getString("triggerName");
+            String triggerName = getString(jsonObject, "triggerName");
             EventTopic eventTopic = EventTopic.getEventTopicByName(triggerName);
             if (eventTopic == null) {
               log.error("Not matched triggerName {} in data {}", triggerName, triggerData);
@@ -471,6 +472,29 @@ public class MongodbSenderImpl implements AutoCloseable {
           }
         }
       };
+
+  private Long getLong(JsonNode node, String key) {
+    JsonNode value = node.get(key);
+    if (Objects.isNull(value) || value.isNull()) {
+      return null;
+    }
+    if (value.isNumber()) {
+      return value.longValue();
+    }
+    String valueText = value.asText(null);
+    if (StringUtils.isNullOrEmpty(valueText)) {
+      return null;
+    }
+    return Long.parseLong(valueText);
+  }
+
+  private String getString(JsonNode node, String key) {
+    JsonNode value = node.get(key);
+    if (Objects.isNull(value) || value.isNull()) {
+      return null;
+    }
+    return value.asText();
+  }
 
   @Override
   public void close() {

--- a/plugins/mongodbplugin/src/main/java/org/tron/mongodb/util/Converter.java
+++ b/plugins/mongodbplugin/src/main/java/org/tron/mongodb/util/Converter.java
@@ -1,21 +1,33 @@
 package org.tron.mongodb.util;
 
-import com.alibaba.fastjson.JSON;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.io.Serializable;
 import org.bson.Document;
 
 public class Converter {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public static Document jsonStringToDocument(String jsonString) {
     return Document.parse(jsonString);
   }
 
   public static String objectToJsonString(Serializable entity) {
-    return JSON.toJSONString(entity);
+    try {
+      return OBJECT_MAPPER.writeValueAsString(entity);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Failed to serialize entity to JSON", e);
+    }
   }
 
   public static <T> T jsonStringToObject(String jsonString, Class<T> clazz) {
-    return JSON.parseObject(jsonString, clazz);
+    try {
+      return OBJECT_MAPPER.readValue(jsonString, clazz);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Failed to deserialize JSON to object", e);
+    }
   }
 
 }


### PR DESCRIPTION
1. Drop com.alibaba:fastjson:1.2.83 in favor of jackson-databind 2.18.6, which java-tron already exposes on the plugin classpath. Bump the jackson version in the mongodb plugin and app from 2.18.3 to 2.18.6 to align with the host.
2. bump plugin version from 1.0.0 to 3.0.0