### PR TITLE
feat(deps): bump kafka-clients and pf4j versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 # PF4J
-pf4jVersion=3.10.0
+pf4jVersion=3.15.0

--- a/plugins/kafkaplugin/build.gradle
+++ b/plugins/kafkaplugin/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.6'
     compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.18.6'
 
-    implementation("org.apache.kafka:kafka-clients:3.9.1") {
+    implementation("org.apache.kafka:kafka-clients:3.9.2") {
         exclude group: "org.slf4j"
         exclude group: 'org.lz4', module: 'lz4-java'
     }


### PR DESCRIPTION
## What does this PR do?

 - bump kafka-clients from 3.9.1 to 3.9.2
 - bump pf4j from 3.10.0 to 3.15.0

## Why are these changes required?

## This PR has been tested by:

## Unit Tests
 - Manual Testing
 - Follow up

## Extra details