### PR TITLE
feat(trigger): add removed field to BlockLogTrigger and TransactionLogTrigger

### DIFF
--- a/api/src/main/java/org/tron/common/logsfilter/trigger/BlockLogTrigger.java
+++ b/api/src/main/java/org/tron/common/logsfilter/trigger/BlockLogTrigger.java
@@ -27,6 +27,13 @@ public class BlockLogTrigger extends Trigger {
   @Setter
   private List<String> transactionList = new ArrayList<>();
 
+  /**
+   * true if the block has been revoked
+   */
+  @Getter
+  @Setter
+  private boolean removed;
+
   public BlockLogTrigger() {
     setTriggerName(EventTopic.BLOCK_TRIGGER.getName());
   }

--- a/api/src/main/java/org/tron/common/logsfilter/trigger/TransactionLogTrigger.java
+++ b/api/src/main/java/org/tron/common/logsfilter/trigger/TransactionLogTrigger.java
@@ -94,6 +94,13 @@ public class TransactionLogTrigger extends Trigger {
   @Setter
   private List<InternalTransactionPojo> internalTrananctionList;
 
+  /**
+   * true if the transaction has been revoked
+   */
+  @Getter
+  @Setter
+  private boolean removed;
+
   public TransactionLogTrigger() {
     setTriggerName(EventTopic.TRANSACTION_TRIGGER.getName());
   }


### PR DESCRIPTION
## What does this PR do?

Add a boolean removed field to BlockLogTrigger and TransactionLogTrigger, mirroring ContractTrigger, so block and transaction events can carry the rollback flag when a chain reorganization revokes them.

## Why are these changes required?

## This PR has been tested by:

## Unit Tests
 - Manual Testing
 - Follow up

## Extra details